### PR TITLE
feat(api): asset search, filters, pagination + fix   double-encoded JSON metadata

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -73,6 +73,18 @@ export async function runMigrations() {
     ALTER TABLE assets ADD INDEX idx_assets_org_id_created (org_id, created_at)
   `).catch(() => { /* index already exists */ });
 
+  // Heal double-encoded JSON columns (legacy rows stored as JSON string scalars, e.g. "'{\"genre\":...}'").
+  // JSON_UNQUOTE extracts the inner text, which the JSON column re-parses into an object.
+  // Guarded by JSON_TYPE/JSON_VALID → no-op on healthy rows (idempotent).
+  for (const column of ['custom_metadata', 'metadata']) {
+    await pool.query(`
+      UPDATE assets SET ${column} = JSON_UNQUOTE(${column})
+      WHERE ${column} IS NOT NULL
+        AND JSON_TYPE(${column}) = 'STRING'
+        AND JSON_VALID(JSON_UNQUOTE(${column}))
+    `);
+  }
+
   await pool.query(`
     CREATE TABLE IF NOT EXISTS renditions (
       id VARCHAR(36) PRIMARY KEY,

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -68,6 +68,11 @@ export async function runMigrations() {
     ALTER TABLE assets ADD COLUMN org_id VARCHAR(36) NULL AFTER id
   `).catch(() => { /* column already exists */ });
 
+  // Composite index for asset listing (org_id filter + created_at sort)
+  await pool.query(`
+    ALTER TABLE assets ADD INDEX idx_assets_org_id_created (org_id, created_at)
+  `).catch(() => { /* index already exists */ });
+
   await pool.query(`
     CREATE TABLE IF NOT EXISTS renditions (
       id VARCHAR(36) PRIMARY KEY,

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -266,10 +266,10 @@ export async function assetRoutes(app: FastifyInstance) {
       }
     }
 
-    // Store AI options in asset metadata
+    // Store AI options in asset metadata (legacy rows may still hold a double-encoded string)
     if (body?.aiOptions) {
       const existing = asset.metadata ? (typeof asset.metadata === 'string' ? JSON.parse(asset.metadata) : asset.metadata) as Record<string, unknown> : {};
-      await db.update(assets).set({ metadata: JSON.stringify({ ...existing, aiOptions: body.aiOptions }) }).where(eq(assets.id, asset.id));
+      await db.update(assets).set({ metadata: { ...existing, aiOptions: body.aiOptions } }).where(eq(assets.id, asset.id));
     }
 
     const jobId = nanoid(ID_LENGTH.JOB);

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -4,12 +4,12 @@ import path from 'node:path';
 import type { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { FastifyInstance } from 'fastify';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray, like, sql, type SQL } from 'drizzle-orm';
 import { DeleteObjectCommand, DeleteObjectsCommand, GetObjectCommand, HeadObjectCommand, ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
-import { assets, jobs, renditions, aiJobs, ASSET_STATUS, SOURCE_TYPE, JOB_STATUS, JOB_TYPE, S3_PATHS, ID_LENGTH, TIER_LIMITS, UNLIMITED_TIER_LIMITS, WEBHOOK_EVENT, METADATA_LIMITS, type OrgTier } from '@hovod/db';
+import { assets, jobs, renditions, aiJobs, ASSET_STATUS, SOURCE_TYPE, JOB_STATUS, JOB_TYPE, S3_PATHS, ID_LENGTH, TIER_LIMITS, UNLIMITED_TIER_LIMITS, WEBHOOK_EVENT, METADATA_LIMITS, type OrgTier, type AssetStatus, type SourceType } from '@hovod/db';
 import { db } from '../db.js';
 import { env, hasStripe } from '../env.js';
 import { s3Client, s3PublicClient } from '../s3.js';
@@ -38,6 +38,28 @@ const importAssetBody = z.object({
     'Only http and https URLs are allowed',
   ),
 });
+
+const assetStatusValues = Object.values(ASSET_STATUS) as [AssetStatus, ...AssetStatus[]];
+const sourceTypeValues = Object.values(SOURCE_TYPE) as [SourceType, ...SourceType[]];
+
+const listAssetsQuery = z.object({
+  q: z.string().trim().min(1).max(255).optional(),
+  status: z.string().max(1024)
+    .transform((s) => [...new Set(s.split(',').map((v) => v.trim()).filter(Boolean))])
+    .refine(
+      (list) => list.length > 0 && list.every((v) => (assetStatusValues as readonly string[]).includes(v)),
+      'Invalid status value',
+    )
+    .optional(),
+  sourceType: z.enum(sourceTypeValues).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional().default(100),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+/** Escape LIKE wildcards so user input matches literally (% and _ don't act as wildcards) */
+function escapeLike(input: string): string {
+  return input.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
 
 export async function assetRoutes(app: FastifyInstance) {
   /* Create asset */
@@ -71,19 +93,38 @@ export async function assetRoutes(app: FastifyInstance) {
     return { data: { id, playbackId, status: ASSET_STATUS.CREATED } };
   });
 
-  /* List assets */
-  app.get('/v1/assets', async (request) => {
-    const list = await db
-      .select()
-      .from(assets)
-      .where(eq(assets.orgId, request.orgId!))
-      .orderBy(desc(assets.createdAt));
+  /* List assets (search + filters + pagination) */
+  app.get<{ Querystring: Record<string, string> }>('/v1/assets', async (request) => {
+    // Metadata filters arrive as dot-notation params: ?metadata.genre=documentary
+    const metadataEntries: Record<string, string> = {};
+    for (const [key, value] of Object.entries(request.query)) {
+      if (key.startsWith('metadata.')) metadataEntries[key.slice('metadata.'.length)] = value;
+    }
+    // Same limits as metadata writes: ≤10 keys, key ≤255, value ≤255
+    const metadataFilters = customMetadataSchema.parse(metadataEntries);
+    const { q, status, sourceType, limit, offset } = listAssetsQuery.parse(request.query);
+
+    const conditions: SQL[] = [eq(assets.orgId, request.orgId!)];
+    if (q) conditions.push(like(assets.title, `%${escapeLike(q)}%`));
+    if (status?.length) conditions.push(inArray(assets.status, status));
+    if (sourceType) conditions.push(eq(assets.sourceType, sourceType));
+    for (const [key, value] of Object.entries(metadataFilters)) {
+      conditions.push(sql`JSON_CONTAINS(${assets.customMetadata}, JSON_OBJECT(${key}, ${value}))`);
+    }
+    const where = and(...conditions);
+
+    const [rows, countResult] = await Promise.all([
+      db.select().from(assets).where(where).orderBy(desc(assets.createdAt)).limit(limit).offset(offset),
+      db.select({ count: sql<number>`COUNT(*)` }).from(assets).where(where),
+    ]);
+
     return {
-      data: list.map((a) => ({
+      data: rows.map((a) => ({
         ...a,
         thumbnailUrl: getThumbnailUrl(a.id, a.status, a.customThumbnailKey),
         hasCustomThumbnail: !!a.customThumbnailKey,
       })),
+      pagination: { total: Number(countResult[0].count), limit, offset },
     };
   });
 

--- a/apps/dashboard/src/pages/VideoDetailPage.tsx
+++ b/apps/dashboard/src/pages/VideoDetailPage.tsx
@@ -42,6 +42,21 @@ function getSourceLabels(t: Translations): Record<string, string> {
   };
 }
 
+/** Legacy rows may store custom metadata double-encoded (a JSON string) — parse before use,
+ *  otherwise Object.entries() renders it one character per line. */
+function normalizeCustomMetadata(value: unknown): Record<string, string> | null {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, string>
+        : null;
+    } catch { return null; }
+  }
+  return value as Record<string, string>;
+}
+
 /** Build AI row config using translated strings */
 function getAiRowCfg(t: Translations): Record<string, { label: string; color: string }> {
   return {
@@ -91,7 +106,7 @@ export function VideoDetailPage() {
           .then((d) => setManifest(d.manifestUrl))
           .catch(() => {}),
       ]);
-      setAsset(a);
+      setAsset({ ...a, customMetadata: normalizeCustomMetadata(a.customMetadata) });
       setError('');
     } catch {
       if (showLoading) setError(t.videoDetail.assetNotFound);

--- a/apps/dashboard/src/pages/VideosPage.tsx
+++ b/apps/dashboard/src/pages/VideosPage.tsx
@@ -13,7 +13,7 @@ export function VideosPage() {
 
   const refresh = useCallback(async () => {
     try {
-      const list = await api<Asset[]>('/v1/assets');
+      const list = await api<Asset[]>('/v1/assets?limit=200');
       setAssets(list);
     } catch { /* ignore polling errors */ }
   }, []);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -98,12 +98,30 @@ curl -X POST http://localhost:3002/v1/assets \
 GET /v1/assets
 ```
 
-Returns all assets ordered by creation date (newest first).
+Returns assets ordered by creation date (newest first), with optional search, filters, and pagination.
 
-**Example**
+**Query Parameters**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `q` | `string` | — | Case-insensitive partial match on `title` |
+| `status` | `string` (CSV) | — | Filter by status: `created,uploaded,queued,processing,ready,error,deleted`. Comma-separated for multiple values (e.g. `?status=ready,error`) |
+| `sourceType` | `string` | — | Filter by source type: `upload` or `url` |
+| `metadata.<key>` | `string` | — | Filter by custom metadata (e.g. `?metadata.genre=documentary`). Exact match, case-sensitive, combined with AND. Max 10 filters |
+| `limit` | `integer` | `100` | Page size (max 200) |
+| `offset` | `integer` | `0` | Page offset |
+
+**Examples**
 
 ```bash
-curl http://localhost:3002/v1/assets
+# Search by title
+curl "http://localhost:3002/v1/assets?q=nature"
+
+# Filter by status + custom metadata
+curl "http://localhost:3002/v1/assets?status=ready&metadata.genre=documentary"
+
+# Paginate
+curl "http://localhost:3002/v1/assets?limit=20&offset=40"
 ```
 
 **Response** `200`
@@ -125,9 +143,12 @@ curl http://localhost:3002/v1/assets
       "createdAt": "2025-06-01T12:00:00.000Z",
       "updatedAt": "2025-06-01T12:05:30.000Z"
     }
-  ]
+  ],
+  "pagination": { "total": 42, "limit": 100, "offset": 0 }
 }
 ```
+
+> `pagination.total` is the total number of matching assets regardless of `limit`/`offset`. Metadata matching is exact and case-sensitive (`?metadata.genre=Documentary` will not match `"documentary"`).
 
 ---
 


### PR DESCRIPTION
  ## Summary

  Extends `GET /v1/assets` with search, filtering (including custom metadata) and
  pagination, and fixes a data corruption bug where JSON metadata columns were
  stored double-encoded, making custom metadata render one character per line in
  the dashboard.

  ## What changed

  ### 1. Search & filtering on `GET /v1/assets` (7b29e10)

  | Param | Example | Behavior |
  |---|---|---|
  | `q` | `?q=nature` | Case-insensitive partial match on `title` (LIKE, wildcards escaped) |
  | `status` | `?status=ready,error` | CSV list validated against `ASSET_STATUS` |
  | `sourceType` | `?sourceType=url` | `upload` \| `url` |
  | `metadata.<key>` | `?metadata.genre=documentary` | Exact match via `JSON_CONTAINS`, same limits as writes (≤10 keys) |
  | `limit` / `offset` | `?limit=20&offset=40` | Defaults 100/0, max 200 |

  - Response adds `pagination: { total, limit, offset }` **alongside** `data` —
    existing consumers reading `.data` are unaffected
  - New composite index `(org_id, created_at)` for the org filter + sort
  - Dashboard requests `?limit=200` to avoid silent truncation
  - `docs/api-reference.md` updated

  ### 2. Fix: double-encoded JSON metadata (f7a4de9)

  Legacy rows stored `custom_metadata`/`metadata` as JSON string scalars; they
  read back as JS strings, so the dashboard's `Object.entries()` rendered one
  character per line. The process endpoint was double-encoding `metadata`
  (Drizzle already serializes `json()` columns).

  - Process endpoint now passes the object directly
  - Idempotent startup migration unwraps affected rows
    (`JSON_UNQUOTE` guarded by `JSON_TYPE`/`JSON_VALID` — no-op on healthy rows)
  - Dashboard normalizes `customMetadata` before use as a defense

  ## Backward compatibility

  - No param → same `data` array as before + new `pagination` key
  - Metadata writes (`POST`/`PATCH`) unchanged

  ## Verification

  - `npm run typecheck` passes on all 4 workspaces
  - 12 isolated tests on the query-parsing layer (Zod transforms, metadata
    dot-notation extraction, limits, LIKE escaping)
  - Repair migration, `JSON_CONTAINS` filters and pagination verified against a
    real MySQL 8.4 instance with the exact Drizzle/mysql2 stack: corrupted rows
    heal to objects, reads return objects, UI renders one row per entry

  ## Notes supplémentaires
J'avais besoin de pouvoir filtrer les vidéos selon les metadata, je pense que cela peut-être utile de manière générale. Merci pour ce projet, très bien fait et bien utile.